### PR TITLE
Fix error in the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ An example Dennis configuration located in `~/.dennis.json` looks like
   "domains": {
     "ilovemyself": {
       "host": "8.8.8.8",
-      "suffix": "com"
+      "suffix": "net"
     }
   }
 }


### PR DESCRIPTION
The example configuration uses "com", but the description uses "net".
